### PR TITLE
Allow for non-strings in JsonReplacerBuilder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ dependencies {
 
 	testImplementation "org.junit.jupiter:junit-jupiter:latest.release"
 	testImplementation "org.assertj:assertj-core:latest.release"
-
+	testImplementation "com.fasterxml.jackson.core:jackson-databind"
+	testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+	testImplementation platform("com.fasterxml.jackson:jackson-bom:latest.release")
 	// Filter release candidates and beta versions
 	components.all { ComponentMetadataDetails details ->
 		if (details.id.version =~ /(?i).+[-.](CANDIDATE|RC|BETA|ALPHA|M\d+).*/) {

--- a/data/test/validation/ValidationFileSampleTest_differentFileFormats.json
+++ b/data/test/validation/ValidationFileSampleTest_differentFileFormats.json
@@ -1,6 +1,6 @@
 {
-"MessageId" : "fb8ca74b-c7a3-4031-8250-bec29280e9ad",
-"TransactionId" : "7047158660679727112",
-"Name" : "Lorem ipsum",
-"Timestamp" : "2020-02-02T12:20:30"
+  "Name" : "Lorem ipsum",
+  "MessageId" : "fb8ca74b-c7a3-4031-8250-bec29280e9ad",
+  "TransactionId" : 7047158660679727112,
+  "Timestamp" : "2020-02-02T12:20:30"
 }

--- a/data/test/validation/ValidationFileSampleTest_normalization_json.json
+++ b/data/test/validation/ValidationFileSampleTest_normalization_json.json
@@ -1,6 +1,6 @@
 {
-"MessageId" : "[masked]",
-"TransactionId" : "[transaction-id]",
-"Name" : "Lorem ipsum",
-"Timestamp" : "2020-02-02T[masked]"
+  "Name" : "Lorem ipsum",
+  "MessageId" : "[masked]",
+  "TransactionId" : "[transaction-id]",
+  "Timestamp" : "2020-02-02T[masked]"
 }

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,6 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.15.2=testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.15.2=testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.15.2=testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2=testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson:jackson-bom:2.15.2=testCompileClasspath,testRuntimeClasspath
 com.googlecode.java-diff-utils:diffutils:1.3.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.assertj:assertj-core:3.19.0=testCompileClasspath,testRuntimeClasspath

--- a/src/main/java/de/cronn/assertions/validationfile/replacements/JsonReplacerBuilder.java
+++ b/src/main/java/de/cronn/assertions/validationfile/replacements/JsonReplacerBuilder.java
@@ -7,7 +7,11 @@ import de.cronn.assertions.validationfile.normalization.ValidationNormalizer;
 
 public class JsonReplacerBuilder extends AbstractJsonReplacer<JsonReplacerBuilder> {
 
-	private String valueToReplace = ".+?";
+	private String valueToReplace =
+			"(null|true|false|" + // booleans
+			"-?\\d+(\\.\\d+)?|" + // numbers
+			"(\".+?(?<!\\\\)\"))"; // strings; don't stop matching if it's escaped with \
+
 	private String replacementValue = "[masked]";
 
 	@Override
@@ -16,13 +20,27 @@ public class JsonReplacerBuilder extends AbstractJsonReplacer<JsonReplacerBuilde
 		Objects.requireNonNull(replacementValue);
 
 		String keyWithQuotationMarks = "\"" + key + "\"";
-		Pattern pattern = Pattern.compile(keyWithQuotationMarks + COLON_WITH_WHITESPACES_GROUP + "\"" + valueToReplace + "\"");
+		Pattern pattern = Pattern.compile(keyWithQuotationMarks + COLON_WITH_WHITESPACES_GROUP + valueToReplace);
 		String replacement = keyWithQuotationMarks + "$1" + "\"" + replacementValue + "\"";
 
 		return new Replacer(pattern, replacement);
 	}
 
+	/**
+	 * @deprecated use withStringValue instead
+	 */
+	@Deprecated()
 	public JsonReplacerBuilder withValue(String value) {
+		this.valueToReplace = "\"" + value + "\"";
+		return this;
+	}
+
+	public JsonReplacerBuilder withStringValue(String value) {
+		this.valueToReplace = "\"" + value + "\"";
+		return this;
+	}
+
+	public JsonReplacerBuilder withRawValue(String value) {
 		this.valueToReplace = value;
 		return this;
 	}

--- a/src/test/java/de/cronn/assertions/validationfile/replacements/JsonReplacerBuilderTest.java
+++ b/src/test/java/de/cronn/assertions/validationfile/replacements/JsonReplacerBuilderTest.java
@@ -2,25 +2,20 @@ package de.cronn.assertions.validationfile.replacements;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import de.cronn.assertions.validationfile.normalization.ValidationNormalizer;
 
 class JsonReplacerBuilderTest {
 
 	@Test
-	void testBuildReplacerForGivenKeyReplacingAnyValue() throws Exception {
-		ValidationNormalizer normalizer = new JsonReplacerBuilder().withKey("key").build();
-
-		String expected = "\"key\": \"[masked]\", \"other\": \"foobar\"";
-		String actual = normalizer.normalize("\"key\": \"foobar\", \"other\": \"foobar\"");
-
-		assertThat(actual).isEqualTo(expected);
-	}
-
-	@Test
 	void testBuildReplacerForGivenKeyReplacingOnlyGivenValue() throws Exception {
-		ValidationNormalizer normalizer = new JsonReplacerBuilder().withKey("key").withValue("abcd").build();
+		ValidationNormalizer normalizer = new JsonReplacerBuilder().withKey("key").withStringValue("abcd").build();
 
 		String expected = "\"key\": \"[masked]\", \"key\": \"foobar\"";
 		String actual = normalizer.normalize("\"key\": \"abcd\", \"key\": \"foobar\"");
@@ -38,4 +33,43 @@ class JsonReplacerBuilderTest {
 		assertThat(actual).isEqualTo(expected);
 	}
 
+
+	private static Stream<Arguments> testBuildReplacerForDifferentValues() {
+		return Stream.of(
+			Arguments.of(
+				"{\"key\": 312.321, \"key\": 123456789, \"key\": -10.4, \"key\": -4}",
+				"{\"key\": \"[masked]\", \"key\": \"[masked]\", \"key\": \"[masked]\", \"key\": \"[masked]\"}"
+			),
+			Arguments.of(
+				"{\"key\": \"Lorem, ipsum\", \"author\": \"Human\"}",
+				"{\"key\": \"[masked]\", \"author\": \"Human\"}"
+			),
+			Arguments.of(
+				"{\"key\": \"Lorem, ipsum. {not object} [not array] More text \\\"Quote\\\" single \\\" \", \"author\": \"Human\"}",
+				"{\"key\": \"[masked]\", \"author\": \"Human\"}"
+			),
+			Arguments.of(
+				"{\"string\": \"Lorem, ipsum\", \"key\": \"Human\"}",
+				"{\"string\": \"Lorem, ipsum\", \"key\": \"[masked]\"}"
+			),
+			Arguments.of(
+				"{\"string\": \"Lorem, ipsum\", \"key\": 1000}",
+				"{\"string\": \"Lorem, ipsum\", \"key\": \"[masked]\"}"
+			),
+			Arguments.of(
+				"\"key\": \"null\"",
+				"\"key\": \"[masked]\""),
+			Arguments.of(
+				"\"key\": true, \"key\": false",
+				"\"key\": \"[masked]\", \"key\": \"[masked]\""
+			)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void testBuildReplacerForDifferentValues(String toNormalize, String expected) {
+		ValidationNormalizer normalizer = new JsonReplacerBuilder().withKey("key").build();
+		assertThat(normalizer.normalize(toNormalize)).isEqualTo(expected);
+	}
 }

--- a/src/test/java/de/cronn/assertions/validationfile/sample/DummySerializer.java
+++ b/src/test/java/de/cronn/assertions/validationfile/sample/DummySerializer.java
@@ -1,12 +1,23 @@
 package de.cronn.assertions.validationfile.sample;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.platform.commons.util.ReflectionUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 final class DummySerializer {
+
+	static ObjectMapper objectMapper = new ObjectMapper()
+		.registerModule(new JavaTimeModule())
+		.setDateFormat(new StdDateFormat())
+		.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 
 	private DummySerializer() {
 	}
@@ -20,10 +31,8 @@ final class DummySerializer {
 		return header + "\n" + values;
 	}
 
-	static String toJsonString(Object obj) {
-		return properties(obj).entrySet().stream()
-			.map(entry -> String.format("\"%s\" : \"%s\"", entry.getKey(), entry.getValue()))
-			.collect(Collectors.joining(",\n", "{\n", "\n}"));
+	static String toJsonString(Object obj) throws IOException {
+		return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
 	}
 
 	static String toXmlString(Object obj) {

--- a/src/test/java/de/cronn/assertions/validationfile/sample/ValidationFileSampleTest.java
+++ b/src/test/java/de/cronn/assertions/validationfile/sample/ValidationFileSampleTest.java
@@ -43,7 +43,7 @@ class ValidationFileSampleTest implements JUnit5ValidationFileAssertions {
 
 		assertWithJsonFile(DummySerializer.toJsonString(sampleStructure), ValidationNormalizer.combine(
 			Replacer.forJson().withKey("MessageId").build(),
-			Replacer.forJson().withKey("TransactionId").withValue("\\d+").withReplacement("[transaction-id]").build(),
+			Replacer.forJson().withKey("TransactionId").withRawValue("\\d+").withReplacement("[transaction-id]").build(),
 			Replacer.forJsonDateTime().withKey("Timestamp").withSourceFormat(ISO_DATE_TIME).withDestinationFormat(normalizedIsoLocalDate()).build()
 		));
 	}


### PR DESCRIPTION
A normalizer `JsonReplacerBuilder` assumed every JSON value would be a string. This was probably not caught because of tests that used a flawed `DummySerializer`

This pull request:
 - Adds Jackson as a `testImplementation` dependency to fix the flawed `DummySerializer.toJsonString()`
 - Removes the assumption of a string value in the Replacer pattern inside `JsonReplacerBuilder`
 - Deprecates `.withValue()` to remove confusion between wanting to search for a string, or wanting to use a regex; replaces it with `.withStringValue()` and `.withRawValue()`
 - Adds a parameterized test for `JsonReplacerBuilder` to check the regex implementation